### PR TITLE
save backward flow with a .flo if requested

### DIFF
--- a/evaluate_flow.py
+++ b/evaluate_flow.py
@@ -794,6 +794,10 @@ def inference_flow(model,
         if save_flo_flow:
             output_file = os.path.join(output_path, os.path.basename(filenames[test_id])[:-4] + '_pred.flo')
             frame_utils.writeFlow(output_file, flow)
+            if pred_bidir_flow:
+                output_file_bwd = os.path.join(output_path, os.path.basename(filenames[test_id])[:-4] + '_pred_bwd.flo')
+                frame_utils.writeFlow(output_file_bwd, flow_bwd)
+
 
     if save_video:
         suffix = '_flow_img.mp4' if concat_flow_img else '_flow.mp4'


### PR DESCRIPTION
this is a simple modification. If users request to output flow as .flo and compute backward flows, save the backwards .flo file.

I'm not sure if some other code (submission, stereo, etc.) needs to also be modified in a similar way but this works for me. Thought you would appreciate a PR to either merge or implement your own mechanism for saving backward flows. 