### PR TITLE
Add argument types to be able to use torch JIT

### DIFF
--- a/unimatch/backbone.py
+++ b/unimatch/backbone.py
@@ -14,10 +14,10 @@ class ResidualBlock(nn.Module):
                                dilation=dilation, padding=dilation, bias=False)
         self.relu = nn.ReLU(inplace=True)
 
-        self.norm1 = norm_layer(planes)
-        self.norm2 = norm_layer(planes)
+        self.norm1 = norm_layer(planes, track_running_stats=True)
+        self.norm2 = norm_layer(planes, track_running_stats=True)
         if not stride == 1 or in_planes != planes:
-            self.norm3 = norm_layer(planes)
+            self.norm3 = norm_layer(planes, track_running_stats=True)
 
         if stride == 1 and in_planes == planes:
             self.downsample = None
@@ -48,7 +48,7 @@ class CNNEncoder(nn.Module):
         feature_dims = [64, 96, 128]
 
         self.conv1 = nn.Conv2d(3, feature_dims[0], kernel_size=7, stride=2, padding=3, bias=False)  # 1/2
-        self.norm1 = norm_layer(feature_dims[0])
+        self.norm1 = norm_layer(feature_dims[0], track_running_stats=True)
         self.relu1 = nn.ReLU(inplace=True)
 
         self.in_planes = feature_dims[0]

--- a/unimatch/geometry.py
+++ b/unimatch/geometry.py
@@ -1,9 +1,9 @@
 import torch
 import torch.nn.functional as F
+from typing import Optional, Tuple
 
-
-def coords_grid(b, h, w, homogeneous=False, device=None):
-    y, x = torch.meshgrid(torch.arange(h), torch.arange(w))  # [H, W]
+def coords_grid(b: int, h: int, w: int, homogeneous: bool = False, device: Optional[torch.device] = None):
+    y, x = torch.meshgrid(torch.arange(h), torch.arange(w), indexing = 'ij')  # [H, W]
 
     stacks = [x, y]
 
@@ -21,24 +21,28 @@ def coords_grid(b, h, w, homogeneous=False, device=None):
     return grid
 
 
-def generate_window_grid(h_min, h_max, w_min, w_max, len_h, len_w, device=None):
+def generate_window_grid(h_min: int, h_max: int, w_min: int, w_max: int, len_h: int, len_w: int, device: Optional[torch.device] = None):
     assert device is not None
 
     x, y = torch.meshgrid([torch.linspace(w_min, w_max, len_w, device=device),
                            torch.linspace(h_min, h_max, len_h, device=device)],
-                          )
+                          indexing = 'ij')
     grid = torch.stack((x, y), -1).transpose(0, 1).float()  # [H, W, 2]
 
     return grid
 
 
-def normalize_coords(coords, h, w):
+def normalize_coords(coords: torch.Tensor, h: int, w: int):
     # coords: [B, H, W, 2]
-    c = torch.Tensor([(w - 1) / 2., (h - 1) / 2.]).float().to(coords.device)
+    c = torch.tensor([(w - 1) / 2., (h - 1) / 2.]).float().to(coords.device)
     return (coords - c) / c  # [-1, 1]
 
 
-def bilinear_sample(img, sample_coords, mode='bilinear', padding_mode='zeros', return_mask=False):
+def bilinear_sample(img: torch.Tensor, sample_coords: torch.Tensor,
+                    mode: str = 'bilinear',
+                    padding_mode: str = 'zeros',
+                    return_mask: bool = False
+                    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     # img: [B, C, H, W]
     # sample_coords: [B, 2, H, W] in image scale
     if sample_coords.size(1) != 2:  # [B, H, W, 2]
@@ -59,10 +63,13 @@ def bilinear_sample(img, sample_coords, mode='bilinear', padding_mode='zeros', r
 
         return img, mask
 
-    return img
+    return img, None
 
 
-def flow_warp(feature, flow, mask=False, padding_mode='zeros'):
+def flow_warp(feature:torch.Tensor, flow: torch.Tensor,
+              mask: bool = False,
+              padding_mode: str = 'zeros'
+              ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     b, c, h, w = feature.size()
     assert flow.size(1) == 2
 
@@ -72,9 +79,9 @@ def flow_warp(feature, flow, mask=False, padding_mode='zeros'):
                            return_mask=mask)
 
 
-def forward_backward_consistency_check(fwd_flow, bwd_flow,
-                                       alpha=0.01,
-                                       beta=0.5
+def forward_backward_consistency_check(fwd_flow: torch.Tensor, bwd_flow: torch.Tensor,
+                                       alpha: float = 0.01,
+                                       beta: float = 0.5
                                        ):
     # fwd_flow, bwd_flow: [B, 2, H, W]
     # alpha and beta values are following UnFlow (https://arxiv.org/abs/1711.07837)
@@ -82,8 +89,8 @@ def forward_backward_consistency_check(fwd_flow, bwd_flow,
     assert fwd_flow.size(1) == 2 and bwd_flow.size(1) == 2
     flow_mag = torch.norm(fwd_flow, dim=1) + torch.norm(bwd_flow, dim=1)  # [B, H, W]
 
-    warped_bwd_flow = flow_warp(bwd_flow, fwd_flow)  # [B, 2, H, W]
-    warped_fwd_flow = flow_warp(fwd_flow, bwd_flow)  # [B, 2, H, W]
+    warped_bwd_flow, _ = flow_warp(bwd_flow, fwd_flow)  # [B, 2, H, W]
+    warped_fwd_flow, _ = flow_warp(fwd_flow, bwd_flow)  # [B, 2, H, W]
 
     diff_fwd = torch.norm(fwd_flow + warped_bwd_flow, dim=1)  # [B, H, W]
     diff_bwd = torch.norm(bwd_flow + warped_fwd_flow, dim=1)
@@ -96,7 +103,7 @@ def forward_backward_consistency_check(fwd_flow, bwd_flow,
     return fwd_occ, bwd_occ
 
 
-def back_project(depth, intrinsics):
+def back_project(depth: torch.Tensor, intrinsics: torch.Tensor):
     # Back project 2D pixel coords to 3D points
     # depth: [B, H, W]
     # intrinsics: [B, 3, 3]
@@ -110,7 +117,10 @@ def back_project(depth, intrinsics):
     return points
 
 
-def camera_transform(points_ref, extrinsics_ref=None, extrinsics_tgt=None, extrinsics_rel=None):
+def camera_transform(points_ref: torch.Tensor,
+                     extrinsics_ref: Optional[torch.Tensor] = None,
+                     extrinsics_tgt: Optional[torch.Tensor] = None,
+                     extrinsics_rel: Optional[torch.Tensor] = None):
     # Transform 3D points from reference camera to target camera
     # points_ref: [B, 3, H, W]
     # extrinsics_ref: [B, 4, 4]
@@ -119,6 +129,8 @@ def camera_transform(points_ref, extrinsics_ref=None, extrinsics_tgt=None, extri
     b, _, h, w = points_ref.shape
 
     if extrinsics_rel is None:
+        assert extrinsics_tgt is not None
+        assert extrinsics_ref is not None
         extrinsics_rel = torch.bmm(extrinsics_tgt, torch.inverse(extrinsics_ref))  # [B, 4, 4]
 
     points_tgt = torch.bmm(extrinsics_rel[:, :3, :3],
@@ -129,7 +141,9 @@ def camera_transform(points_ref, extrinsics_ref=None, extrinsics_tgt=None, extri
     return points_tgt
 
 
-def reproject(points_tgt, intrinsics, return_mask=False):
+def reproject(points_tgt: torch.Tensor, intrinsics: torch.Tensor,
+              return_mask: bool = False
+              ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     # reproject to target view
     # points_tgt: [B, 3, H, W]
     # intrinsics: [B, 3, 3]
@@ -151,11 +165,15 @@ def reproject(points_tgt, intrinsics, return_mask=False):
 
         return pixel_coords, mask
 
-    return pixel_coords
+    return pixel_coords, None
 
 
-def reproject_coords(depth_ref, intrinsics, extrinsics_ref=None, extrinsics_tgt=None, extrinsics_rel=None,
-                     return_mask=False):
+def reproject_coords(depth_ref: torch.Tensor, intrinsics: torch.Tensor,
+                     extrinsics_ref: Optional[torch.Tensor] = None,
+                     extrinsics_tgt: Optional[torch.Tensor] = None,
+                     extrinsics_rel: Optional[torch.Tensor] = None,
+                     return_mask: bool = False
+                     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     # Compute reprojection sample coords
     points_ref = back_project(depth_ref, intrinsics)  # [B, 3, H, W]
     points_tgt = camera_transform(points_ref, extrinsics_ref, extrinsics_tgt, extrinsics_rel=extrinsics_rel)
@@ -166,15 +184,18 @@ def reproject_coords(depth_ref, intrinsics, extrinsics_ref=None, extrinsics_tgt=
 
         return reproj_coords, mask
 
-    reproj_coords = reproject(points_tgt, intrinsics,
+    reproj_coords, _ = reproject(points_tgt, intrinsics,
                               return_mask=return_mask)  # [B, 2, H, W] in image scale
 
-    return reproj_coords
+    return reproj_coords, None
 
 
-def compute_flow_with_depth_pose(depth_ref, intrinsics,
-                                 extrinsics_ref=None, extrinsics_tgt=None, extrinsics_rel=None,
-                                 return_mask=False):
+def compute_flow_with_depth_pose(depth_ref: torch.Tensor, intrinsics: torch.Tensor,
+                                 extrinsics_ref: Optional[torch.Tensor] = None,
+                                 extrinsics_tgt: Optional[torch.Tensor] = None,
+                                 extrinsics_rel: Optional[torch.Tensor] = None,
+                                 return_mask: bool = False
+                                 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     b, h, w = depth_ref.shape
     coords_init = coords_grid(b, h, w, device=depth_ref.device)  # [B, 2, H, W]
 
@@ -186,10 +207,10 @@ def compute_flow_with_depth_pose(depth_ref, intrinsics,
 
         return rigid_flow, mask
 
-    reproj_coords = reproject_coords(depth_ref, intrinsics, extrinsics_ref, extrinsics_tgt,
+    reproj_coords, _ = reproject_coords(depth_ref, intrinsics, extrinsics_ref, extrinsics_tgt,
                                      extrinsics_rel=extrinsics_rel,
                                      return_mask=return_mask)  # [B, 2, H, W]
 
     rigid_flow = reproj_coords - coords_init
 
-    return rigid_flow
+    return rigid_flow, None

--- a/unimatch/matching.py
+++ b/unimatch/matching.py
@@ -1,12 +1,13 @@
 import torch
 import torch.nn.functional as F
+from typing import Tuple
 
 from .geometry import coords_grid, generate_window_grid, normalize_coords
 
 
-def global_correlation_softmax(feature0, feature1,
-                               pred_bidir_flow=False,
-                               ):
+def global_correlation_softmax(feature0: torch.Tensor, feature1: torch.Tensor,
+                               pred_bidir_flow: bool = False,
+                               ) -> Tuple[torch.Tensor, torch.Tensor]:
     # global correlation
     b, c, h, w = feature0.shape
     feature0 = feature0.view(b, c, -1).permute(0, 2, 1)  # [B, H*W, C]
@@ -36,9 +37,9 @@ def global_correlation_softmax(feature0, feature1,
     return flow, prob
 
 
-def local_correlation_softmax(feature0, feature1, local_radius,
-                              padding_mode='zeros',
-                              ):
+def local_correlation_softmax(feature0: torch.Tensor, feature1: torch.Tensor, local_radius: int,
+                              padding_mode: str = 'zeros',
+                              ) -> Tuple[torch.Tensor, torch.Tensor]:
     b, c, h, w = feature0.size()
     coords_init = coords_grid(b, h, w).to(feature0.device)  # [B, 2, H, W]
     coords = coords_init.view(b, 2, -1).permute(0, 2, 1)  # [B, H*W, 2]
@@ -83,12 +84,12 @@ def local_correlation_softmax(feature0, feature1, local_radius,
     return flow, match_prob
 
 
-def local_correlation_with_flow(feature0, feature1,
-                                flow,
-                                local_radius,
-                                padding_mode='zeros',
-                                dilation=1,
-                                ):
+def local_correlation_with_flow(feature0: torch.Tensor, feature1: torch.Tensor,
+                                flow: torch.Tensor,
+                                local_radius: int,
+                                padding_mode: str = 'zeros',
+                                dilation: int = 1,
+                                ) -> torch.Tensor:
     b, c, h, w = feature0.size()
     coords_init = coords_grid(b, h, w).to(feature0.device)  # [B, 2, H, W]
     coords = coords_init.view(b, 2, -1).permute(0, 2, 1)  # [B, H*W, 2]
@@ -123,8 +124,7 @@ def local_correlation_with_flow(feature0, feature1,
     return corr
 
 
-def global_correlation_softmax_stereo(feature0, feature1,
-                                      ):
+def global_correlation_softmax_stereo(feature0: torch.Tensor, feature1: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     # global correlation on horizontal direction
     b, c, h, w = feature0.shape
 
@@ -151,8 +151,7 @@ def global_correlation_softmax_stereo(feature0, feature1,
     return disparity.unsqueeze(1), prob  # feature resolution
 
 
-def local_correlation_softmax_stereo(feature0, feature1, local_radius,
-                                     ):
+def local_correlation_softmax_stereo(feature0: torch.Tensor, feature1: torch.Tensor, local_radius: int) -> Tuple[torch.Tensor, torch.Tensor]:
     b, c, h, w = feature0.size()
     coords_init = coords_grid(b, h, w).to(feature0.device)  # [B, 2, H, W]
     coords = coords_init.view(b, 2, -1).permute(0, 2, 1).contiguous()  # [B, H*W, 2]
@@ -200,13 +199,13 @@ def local_correlation_softmax_stereo(feature0, feature1, local_radius,
     return flow_x, match_prob
 
 
-def correlation_softmax_depth(feature0, feature1,
-                              intrinsics,
-                              pose,
-                              depth_candidates,
-                              depth_from_argmax=False,
-                              pred_bidir_depth=False,
-                              ):
+def correlation_softmax_depth(feature0: torch.Tensor, feature1: torch.Tensor,
+                              intrinsics: torch.Tensor,
+                              pose: torch.Tensor,
+                              depth_candidates: torch.Tensor,
+                              depth_from_argmax: bool = False,
+                              pred_bidir_depth: bool = False,
+                              ) -> Tuple[torch.Tensor, torch.Tensor]:
     b, c, h, w = feature0.size()
     assert depth_candidates.dim() == 4  # [B, D, H, W]
     scale_factor = c ** 0.5
@@ -236,9 +235,9 @@ def correlation_softmax_depth(feature0, feature1,
     return depth, match_prob
 
 
-def warp_with_pose_depth_candidates(feature1, intrinsics, pose, depth,
-                                    clamp_min_depth=1e-3,
-                                    ):
+def warp_with_pose_depth_candidates(feature1: torch.Tensor, intrinsics: torch.Tensor, pose: torch.Tensor, depth: torch.Tensor,
+                                    clamp_min_depth: float = 1e-3,
+                                    ) -> torch.Tensor:
     """
     feature1: [B, C, H, W]
     intrinsics: [B, 3, 3]

--- a/unimatch/trident_conv.py
+++ b/unimatch/trident_conv.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 from torch.nn.modules.utils import _pair
+from typing import List
 
 
 class MultiScaleTridentConv(nn.Module):
@@ -61,7 +62,7 @@ class MultiScaleTridentConv(nn.Module):
         if self.bias is not None:
             nn.init.constant_(self.bias, 0)
 
-    def forward(self, inputs):
+    def forward(self, inputs: List[torch.Tensor]):
         num_branch = self.num_branch if self.training or self.test_branch_idx == -1 else 1
         assert len(inputs) == num_branch
 

--- a/unimatch/utils.py
+++ b/unimatch/utils.py
@@ -1,26 +1,27 @@
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 from .position import PositionEmbeddingSine
+from typing import Tuple
 
-
-def generate_window_grid(h_min, h_max, w_min, w_max, len_h, len_w, device=None):
+def generate_window_grid(h_min: int, h_max: int, w_min: int, w_max: int, len_h: int, len_w: int, device: torch.device = None) -> torch.Tensor:
     assert device is not None
 
     x, y = torch.meshgrid([torch.linspace(w_min, w_max, len_w, device=device),
                            torch.linspace(h_min, h_max, len_h, device=device)],
-                          )
+                          indexing = 'ij')
     grid = torch.stack((x, y), -1).transpose(0, 1).float()  # [H, W, 2]
 
     return grid
 
 
-def normalize_coords(coords, h, w):
+def normalize_coords(coords: torch.Tensor, h: int, w: int) -> torch.Tensor:
     # coords: [B, H, W, 2]
     c = torch.Tensor([(w - 1) / 2., (h - 1) / 2.]).float().to(coords.device)
     return (coords - c) / c  # [-1, 1]
 
 
-def normalize_img(img0, img1):
+def normalize_img(img0: torch.Tensor, img1: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     # loaded images are in [0, 255]
     # normalize by ImageNet mean and std
     mean = torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1).to(img1.device)
@@ -30,109 +31,113 @@ def normalize_img(img0, img1):
 
     return img0, img1
 
+class split_feature(nn.Module):
+    def forward(self, feature: torch.Tensor, num_splits: int = 2, channel_last: bool = False) -> torch.Tensor:
+        if channel_last:  # [B, H, W, C]
+            b, h, w, c = feature.size()
+            assert h % num_splits == 0 and w % num_splits == 0
 
-def split_feature(feature,
-                  num_splits=2,
-                  channel_last=False,
-                  ):
-    if channel_last:  # [B, H, W, C]
-        b, h, w, c = feature.size()
-        assert h % num_splits == 0 and w % num_splits == 0
+            b_new = b * num_splits * num_splits
+            h_new = h // num_splits
+            w_new = w // num_splits
 
-        b_new = b * num_splits * num_splits
-        h_new = h // num_splits
-        w_new = w // num_splits
+            feature = feature.view(b, num_splits, h // num_splits, num_splits, w // num_splits, c
+                                ).permute(0, 1, 3, 2, 4, 5).reshape(b_new, h_new, w_new, c)  # [B*K*K, H/K, W/K, C]
+        else:  # [B, C, H, W]
+            b, c, h, w = feature.size()
+            assert h % num_splits == 0 and w % num_splits == 0
 
-        feature = feature.view(b, num_splits, h // num_splits, num_splits, w // num_splits, c
-                               ).permute(0, 1, 3, 2, 4, 5).reshape(b_new, h_new, w_new, c)  # [B*K*K, H/K, W/K, C]
-    else:  # [B, C, H, W]
-        b, c, h, w = feature.size()
-        assert h % num_splits == 0 and w % num_splits == 0
+            b_new = b * num_splits * num_splits
+            h_new = h // num_splits
+            w_new = w // num_splits
 
-        b_new = b * num_splits * num_splits
-        h_new = h // num_splits
-        w_new = w // num_splits
+            feature = feature.view(b, c, num_splits, h // num_splits, num_splits, w // num_splits
+                                ).permute(0, 2, 4, 1, 3, 5).reshape(b_new, c, h_new, w_new)  # [B*K*K, C, H/K, W/K]
 
-        feature = feature.view(b, c, num_splits, h // num_splits, num_splits, w // num_splits
-                               ).permute(0, 2, 4, 1, 3, 5).reshape(b_new, c, h_new, w_new)  # [B*K*K, C, H/K, W/K]
+        return feature
 
-    return feature
+class merge_splits(nn.Module):
+    def forward(self, splits: torch.Tensor, num_splits: int = 2, channel_last: bool = False) -> torch.Tensor:
+        if channel_last:  # [B*K*K, H/K, W/K, C]
+            b, h, w, c = splits.size()
+            new_b = b // num_splits // num_splits
+
+            splits = splits.view(new_b, num_splits, num_splits, h, w, c)
+            merge = splits.permute(0, 1, 3, 2, 4, 5).contiguous().view(
+                new_b, num_splits * h, num_splits * w, c)  # [B, H, W, C]
+        else:  # [B*K*K, C, H/K, W/K]
+            b, c, h, w = splits.size()
+            new_b = b // num_splits // num_splits
+
+            splits = splits.view(new_b, num_splits, num_splits, c, h, w)
+            merge = splits.permute(0, 3, 1, 4, 2, 5).contiguous().view(
+                new_b, c, num_splits * h, num_splits * w)  # [B, C, H, W]
+
+        return merge
+
+class generate_shift_window_attn_mask(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.split_feature = split_feature()
+
+    def forward(self, input_resolution: Tuple[int, int], window_size_h: int, window_size_w: int, shift_size_h: int, shift_size_w: int, device: torch.device = torch.device('cuda')) -> torch.Tensor:
+        # ref: https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py
+        # calculate attention mask for SW-MSA
+        h, w = input_resolution
+
+        mask1 = torch.ones((h - window_size_h,            w - window_size_w           )).to(device) * 0
+        mask2 = torch.ones((h - window_size_h,            window_size_w - shift_size_w)).to(device) * 1
+        mask3 = torch.ones((h - window_size_h,            shift_size_w                )).to(device) * 2
+        mask4 = torch.ones((window_size_h - shift_size_h, w - window_size_w           )).to(device) * 3
+        mask5 = torch.ones((window_size_h - shift_size_h, window_size_w - shift_size_w)).to(device) * 4
+        mask6 = torch.ones((window_size_h - shift_size_h, shift_size_w                )).to(device) * 5
+        mask7 = torch.ones((shift_size_h,                 w - window_size_w           )).to(device) * 6
+        mask8 = torch.ones((shift_size_h,                 window_size_w - shift_size_w)).to(device) * 7
+        mask9 = torch.ones((shift_size_h,                 shift_size_w                )).to(device) * 8
+        # Concatenate the masks to create the full mask
+        upper_mask  = torch.cat([mask1, mask2, mask3], dim=1)
+        middle_mask = torch.cat([mask4, mask5, mask6], dim=1)
+        lower_mask  = torch.cat([mask7, mask8, mask9], dim=1)
+        img_mask = torch.cat([upper_mask, middle_mask, lower_mask], dim=0).unsqueeze(0).unsqueeze(-1) # Add extra dimensions for batch size and channels
+
+        mask_windows = self.split_feature(img_mask, num_splits=input_resolution[-1] // window_size_w, channel_last=True)
+
+        mask_windows = mask_windows.view(-1, window_size_h * window_size_w)
+        attn_mask = mask_windows.unsqueeze(1) - mask_windows.unsqueeze(2)
+        attn_mask = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(attn_mask == 0, float(0.0))
+
+        return attn_mask
+
+class feature_add_position(nn.Module):
+    def __init__(self, feature_channels: int):
+        super().__init__()
+        self.split_feature = split_feature()
+        self.merge_splits = merge_splits()
+        self.pos_enc = PositionEmbeddingSine(num_pos_feats=feature_channels // 2)
+
+    def forward(self, feature0: torch.Tensor, feature1: torch.Tensor, attn_splits: int, feature_channels: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        if attn_splits > 1:  # add position in splited window
+            feature0_splits = self.split_feature(feature0, num_splits=attn_splits)
+            feature1_splits = self.split_feature(feature1, num_splits=attn_splits)
+
+            position = self.pos_enc(feature0_splits)
+
+            feature0_splits = feature0_splits + position
+            feature1_splits = feature1_splits + position
+
+            feature0 = self.merge_splits(feature0_splits, num_splits=attn_splits)
+            feature1 = self.merge_splits(feature1_splits, num_splits=attn_splits)
+        else:
+            position = self.pos_enc(feature0)
+
+            feature0 = feature0 + position
+            feature1 = feature1 + position
+
+        return feature0, feature1
 
 
-def merge_splits(splits,
-                 num_splits=2,
-                 channel_last=False,
-                 ):
-    if channel_last:  # [B*K*K, H/K, W/K, C]
-        b, h, w, c = splits.size()
-        new_b = b // num_splits // num_splits
-
-        splits = splits.view(new_b, num_splits, num_splits, h, w, c)
-        merge = splits.permute(0, 1, 3, 2, 4, 5).contiguous().view(
-            new_b, num_splits * h, num_splits * w, c)  # [B, H, W, C]
-    else:  # [B*K*K, C, H/K, W/K]
-        b, c, h, w = splits.size()
-        new_b = b // num_splits // num_splits
-
-        splits = splits.view(new_b, num_splits, num_splits, c, h, w)
-        merge = splits.permute(0, 3, 1, 4, 2, 5).contiguous().view(
-            new_b, c, num_splits * h, num_splits * w)  # [B, C, H, W]
-
-    return merge
-
-
-def generate_shift_window_attn_mask(input_resolution, window_size_h, window_size_w,
-                                    shift_size_h, shift_size_w, device=torch.device('cuda')):
-    # ref: https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py
-    # calculate attention mask for SW-MSA
-    h, w = input_resolution
-    img_mask = torch.zeros((1, h, w, 1)).to(device)  # 1 H W 1
-    h_slices = (slice(0, -window_size_h),
-                slice(-window_size_h, -shift_size_h),
-                slice(-shift_size_h, None))
-    w_slices = (slice(0, -window_size_w),
-                slice(-window_size_w, -shift_size_w),
-                slice(-shift_size_w, None))
-    cnt = 0
-    for h in h_slices:
-        for w in w_slices:
-            img_mask[:, h, w, :] = cnt
-            cnt += 1
-
-    mask_windows = split_feature(img_mask, num_splits=input_resolution[-1] // window_size_w, channel_last=True)
-
-    mask_windows = mask_windows.view(-1, window_size_h * window_size_w)
-    attn_mask = mask_windows.unsqueeze(1) - mask_windows.unsqueeze(2)
-    attn_mask = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(attn_mask == 0, float(0.0))
-
-    return attn_mask
-
-
-def feature_add_position(feature0, feature1, attn_splits, feature_channels):
-    pos_enc = PositionEmbeddingSine(num_pos_feats=feature_channels // 2)
-
-    if attn_splits > 1:  # add position in splited window
-        feature0_splits = split_feature(feature0, num_splits=attn_splits)
-        feature1_splits = split_feature(feature1, num_splits=attn_splits)
-
-        position = pos_enc(feature0_splits)
-
-        feature0_splits = feature0_splits + position
-        feature1_splits = feature1_splits + position
-
-        feature0 = merge_splits(feature0_splits, num_splits=attn_splits)
-        feature1 = merge_splits(feature1_splits, num_splits=attn_splits)
-    else:
-        position = pos_enc(feature0)
-
-        feature0 = feature0 + position
-        feature1 = feature1 + position
-
-    return feature0, feature1
-
-
-def upsample_flow_with_mask(flow, up_mask, upsample_factor,
-                            is_depth=False):
+def upsample_flow_with_mask(flow: torch.Tensor, up_mask: torch.Tensor, upsample_factor: int,
+                            is_depth: bool = False) -> torch.Tensor:
     # convex upsampling following raft
 
     mask = up_mask
@@ -151,38 +156,32 @@ def upsample_flow_with_mask(flow, up_mask, upsample_factor,
 
     return up_flow
 
+class split_feature_1d(nn.Module):
+    def forward(self, feature: torch.Tensor, num_splits: int = 2) -> torch.Tensor:
+        # feature: [B, W, C]
+        b, w, c = feature.size()
+        assert w % num_splits == 0
 
-def split_feature_1d(feature,
-                     num_splits=2,
-                     ):
-    # feature: [B, W, C]
-    b, w, c = feature.size()
-    assert w % num_splits == 0
+        b_new = b * num_splits
+        w_new = w // num_splits
 
-    b_new = b * num_splits
-    w_new = w // num_splits
+        feature = feature.view(b, num_splits, w // num_splits, c
+                            ).view(b_new, w_new, c)  # [B*K, W/K, C]
 
-    feature = feature.view(b, num_splits, w // num_splits, c
-                           ).view(b_new, w_new, c)  # [B*K, W/K, C]
+        return feature
 
-    return feature
+class merge_splits_1d(nn.Module):
+    def forward(self, splits: torch.Tensor, h: int, num_splits: int = 2) -> torch.Tensor:
+        b, w, c = splits.size()
+        new_b = b // num_splits // h
 
+        splits = splits.view(new_b, h, num_splits, w, c)
+        merge = splits.view(
+            new_b, h, num_splits * w, c)  # [B, H, W, C]
 
-def merge_splits_1d(splits,
-                    h,
-                    num_splits=2,
-                    ):
-    b, w, c = splits.size()
-    new_b = b // num_splits // h
+        return merge
 
-    splits = splits.view(new_b, h, num_splits, w, c)
-    merge = splits.view(
-        new_b, h, num_splits * w, c)  # [B, H, W, C]
-
-    return merge
-
-
-def window_partition_1d(x, window_size_w):
+def window_partition_1d(x: torch.Tensor, window_size_w: int) -> torch.Tensor:
     """
     Args:
         x: (B, W, C)
@@ -195,22 +194,19 @@ def window_partition_1d(x, window_size_w):
     x = x.view(B, W // window_size_w, window_size_w, C).view(-1, window_size_w, C)
     return x
 
+class generate_shift_window_attn_mask_1d(nn.Module):
+    def forward(self, input_w: int, window_size_w: int, shift_size_w: int, device: torch.device = torch.device('cuda')) -> torch.Tensor:
+        # calculate attention mask for SW-MSA
 
-def generate_shift_window_attn_mask_1d(input_w, window_size_w,
-                                       shift_size_w, device=torch.device('cuda')):
-    # calculate attention mask for SW-MSA
-    img_mask = torch.zeros((1, input_w, 1)).to(device)  # 1 W 1
-    w_slices = (slice(0, -window_size_w),
-                slice(-window_size_w, -shift_size_w),
-                slice(-shift_size_w, None))
-    cnt = 0
-    for w in w_slices:
-        img_mask[:, w, :] = cnt
-        cnt += 1
+        mask1 = torch.ones((0, input_w - window_size_w     )).to(device) * 0
+        mask2 = torch.ones((0, window_size_w - shift_size_w)).to(device) * 1
+        mask3 = torch.ones((0, shift_size_w                )).to(device) * 2
+        # Concatenate the masks to create the full mask
+        img_mask = torch.cat([mask1, mask2, mask3], dim=1).unsqueeze(0).unsqueeze(-1)
 
-    mask_windows = window_partition_1d(img_mask, window_size_w)  # nW, window_size, 1
-    mask_windows = mask_windows.view(-1, window_size_w)
-    attn_mask = mask_windows.unsqueeze(1) - mask_windows.unsqueeze(2)  # nW, window_size, window_size
-    attn_mask = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(attn_mask == 0, float(0.0))
+        mask_windows = window_partition_1d(img_mask, window_size_w)  # nW, window_size, 1
+        mask_windows = mask_windows.view(-1, window_size_w)
+        attn_mask = mask_windows.unsqueeze(1) - mask_windows.unsqueeze(2)  # nW, window_size, window_size
+        attn_mask = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(attn_mask == 0, float(0.0))
 
-    return attn_mask
+        return attn_mask

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -61,9 +61,10 @@ def bilinear_sampler(img, coords, mode='bilinear', mask=False, padding_mode='zer
 def coords_grid(batch, ht, wd, normalize=False):
     if normalize:  # [-1, 1]
         coords = torch.meshgrid(2 * torch.arange(ht) / (ht - 1) - 1,
-                                2 * torch.arange(wd) / (wd - 1) - 1)
+                                2 * torch.arange(wd) / (wd - 1) - 1,
+                                indexing = 'ij')
     else:
-        coords = torch.meshgrid(torch.arange(ht), torch.arange(wd))
+        coords = torch.meshgrid(torch.arange(ht), torch.arange(wd), indexing = 'ij')
     coords = torch.stack(coords[::-1], dim=0).float()
     return coords[None].repeat(batch, 1, 1, 1)  # [B, 2, H, W]
 


### PR DESCRIPTION
This PR adds types to function signatures to be able to use `torch.jit` or `torch.onnx.export()`. I also had to convert some functions to modules

The code should be equivalent to the previous one, I verified that with inference (I didn't test training though)

It's easiest to review this without whitespace diff

Related to #29 