### PR TITLE
Add PyTorchModelHubMixin for better HF integration

### DIFF
--- a/unimatch/unimatch.py
+++ b/unimatch/unimatch.py
@@ -12,8 +12,11 @@ from .geometry import flow_warp, compute_flow_with_depth_pose
 from .reg_refine import BasicUpdateBlock
 from .utils import normalize_img, feature_add_position, upsample_flow_with_mask
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class UniMatch(nn.Module):
+
+class UniMatch(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/autonomousvision/unimatch",
+               pipeline_tag="any-to-any", tags=["depth-estimation", "optical-flow-estimation", "disparity-estimation"], license="mit")
     def __init__(self,
                  num_scales=1,
                  feature_channels=128,


### PR DESCRIPTION
Hi @haofeixu,

Thanks for this nice work, great to see a [demo](https://huggingface.co/spaces/haofeixu/unimatch) for UniMatch being released on the hub! I indexed the paper here: https://huggingface.co/papers/2211.05783. Right now, it does not show linked models/Spaces.

This PR proposes to integrate the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class developed by the 🤗 team to make sure a custom PyTorch model like yours:
- automatically inherits `from_pretrained` and `push_to_hub` methods
- has better metadata
- has working download stats.

Usage is as follows:

```python
from unimatch.unimatch import UniMatch
from huggingface_hub import hf_hub_download

# Load a pre-trained model
model = UniMatch(...)
filepath = hf_hub_download(repo_id="jhaofeixu/unimatch", filename="pretrained/gmflow-scale2-regrefine6-mixdata-train320x576-4e7b215d.pth", repo_type="space")
model.load_state_dict(filepath, map_location="cpu")

# One can optionally push this to the hub
model.push_to_hub("jhaofeixu/unimatch-gmflow-scale2-regrefine6-mixdata-train320x576")

# Can now be reloaded as follows (and will increment download count)
model = UniMatch.from_pretrained("jhaofeixu/unimatch-gmflow-scale2-regrefine6-mixdata-train320x576")
```

So to push each of the UniMatch checkpoints, one would need to run the script as shown above.

Besides that, one can link the models/Spaces demo to the paper page (by including this link: https://huggingface.co/papers/2211.05783 in the respective READMEs).

Let me know whether you need any help!

Kind regards,

Niels from HF